### PR TITLE
build(deps): bump chevrotain from 9.0.1 to 10.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.8.3",
       "license": "MIT",
       "dependencies": {
-        "chevrotain": "^9.0.1",
+        "chevrotain": "^10.5.0",
         "commander": "^2.20.3",
         "lodash.get": "^4.4.2"
       },
@@ -575,15 +575,34 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "node_modules/@chevrotain/cst-dts-gen": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-10.5.0.tgz",
+      "integrity": "sha512-lhmC/FyqQ2o7pGK4Om+hzuDrm9rhFYIJ/AXoQBeongmn870Xeb0L6oGEiuR8nohFNL5sMaQEJWCxr1oIVIVXrw==",
+      "dependencies": {
+        "@chevrotain/gast": "10.5.0",
+        "@chevrotain/types": "10.5.0",
+        "lodash": "4.17.21"
+      }
+    },
+    "node_modules/@chevrotain/gast": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-10.5.0.tgz",
+      "integrity": "sha512-pXdMJ9XeDAbgOWKuD1Fldz4ieCs6+nLNmyVhe2gZVqoO7v8HXuHYs5OV2EzUtbuai37TlOAQHrTDvxMnvMJz3A==",
+      "dependencies": {
+        "@chevrotain/types": "10.5.0",
+        "lodash": "4.17.21"
+      }
+    },
     "node_modules/@chevrotain/types": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-9.0.1.tgz",
-      "integrity": "sha512-jyIgbvb0Vz3OhLdImiufolBxRNAPFhpZmWuNWQ9ffU+nsxLJ0a0yObRCkdT2MKGXolwLZow3r8zhVr/7f5yNSA=="
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-10.5.0.tgz",
+      "integrity": "sha512-f1MAia0x/pAVPWH/T73BJVyO2XU5tI4/iE7cnxb7tqdNTNhQI3Uq3XkqcoteTmD4t1aM0LbHCJOhgIDn07kl2A=="
     },
     "node_modules/@chevrotain/utils": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-9.0.0.tgz",
-      "integrity": "sha512-J0uI+VxqCMiTFmVD95dfZr1QxJcw1RMQc7X3umMAfEcG5f2uWrZeyX0h3hURvXgzUcK6vXH5r+SNv+4bPxWpdg=="
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-10.5.0.tgz",
+      "integrity": "sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ=="
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -2738,12 +2757,15 @@
       "dev": true
     },
     "node_modules/chevrotain": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-9.0.1.tgz",
-      "integrity": "sha512-7rFWS+G8yavnYK5AcqSL9mSXPRfz+atuwM4Hq5Ph/CNM7n7zl3woPXMGWS+cdxSD01nic4PozN12zaw1Fu8cug==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-10.5.0.tgz",
+      "integrity": "sha512-Pkv5rBY3+CsHOYfV5g/Vs5JY9WTHHDEKOlohI2XeygaZhUeqhAlldZ8Hz9cRmxu709bvS08YzxHdTPHhffc13A==",
       "dependencies": {
-        "@chevrotain/types": "^9.0.1",
-        "@chevrotain/utils": "^9.0.0",
+        "@chevrotain/cst-dts-gen": "10.5.0",
+        "@chevrotain/gast": "10.5.0",
+        "@chevrotain/types": "10.5.0",
+        "@chevrotain/utils": "10.5.0",
+        "lodash": "4.17.21",
         "regexp-to-ast": "0.5.0"
       }
     },
@@ -6543,8 +6565,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.capitalize": {
       "version": "4.2.1",
@@ -10440,15 +10461,34 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@chevrotain/cst-dts-gen": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-10.5.0.tgz",
+      "integrity": "sha512-lhmC/FyqQ2o7pGK4Om+hzuDrm9rhFYIJ/AXoQBeongmn870Xeb0L6oGEiuR8nohFNL5sMaQEJWCxr1oIVIVXrw==",
+      "requires": {
+        "@chevrotain/gast": "10.5.0",
+        "@chevrotain/types": "10.5.0",
+        "lodash": "4.17.21"
+      }
+    },
+    "@chevrotain/gast": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-10.5.0.tgz",
+      "integrity": "sha512-pXdMJ9XeDAbgOWKuD1Fldz4ieCs6+nLNmyVhe2gZVqoO7v8HXuHYs5OV2EzUtbuai37TlOAQHrTDvxMnvMJz3A==",
+      "requires": {
+        "@chevrotain/types": "10.5.0",
+        "lodash": "4.17.21"
+      }
+    },
     "@chevrotain/types": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-9.0.1.tgz",
-      "integrity": "sha512-jyIgbvb0Vz3OhLdImiufolBxRNAPFhpZmWuNWQ9ffU+nsxLJ0a0yObRCkdT2MKGXolwLZow3r8zhVr/7f5yNSA=="
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-10.5.0.tgz",
+      "integrity": "sha512-f1MAia0x/pAVPWH/T73BJVyO2XU5tI4/iE7cnxb7tqdNTNhQI3Uq3XkqcoteTmD4t1aM0LbHCJOhgIDn07kl2A=="
     },
     "@chevrotain/utils": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-9.0.0.tgz",
-      "integrity": "sha512-J0uI+VxqCMiTFmVD95dfZr1QxJcw1RMQc7X3umMAfEcG5f2uWrZeyX0h3hURvXgzUcK6vXH5r+SNv+4bPxWpdg=="
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-10.5.0.tgz",
+      "integrity": "sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ=="
     },
     "@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -12128,12 +12168,15 @@
       "dev": true
     },
     "chevrotain": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-9.0.1.tgz",
-      "integrity": "sha512-7rFWS+G8yavnYK5AcqSL9mSXPRfz+atuwM4Hq5Ph/CNM7n7zl3woPXMGWS+cdxSD01nic4PozN12zaw1Fu8cug==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-10.5.0.tgz",
+      "integrity": "sha512-Pkv5rBY3+CsHOYfV5g/Vs5JY9WTHHDEKOlohI2XeygaZhUeqhAlldZ8Hz9cRmxu709bvS08YzxHdTPHhffc13A==",
       "requires": {
-        "@chevrotain/types": "^9.0.1",
-        "@chevrotain/utils": "^9.0.0",
+        "@chevrotain/cst-dts-gen": "10.5.0",
+        "@chevrotain/gast": "10.5.0",
+        "@chevrotain/types": "10.5.0",
+        "@chevrotain/utils": "10.5.0",
+        "lodash": "4.17.21",
         "regexp-to-ast": "0.5.0"
       }
     },
@@ -14922,8 +14965,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.capitalize": {
       "version": "4.2.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "README.md"
   ],
   "dependencies": {
-    "chevrotain": "^9.0.1",
+    "chevrotain": "^10.5.0",
     "commander": "^2.20.3",
     "lodash.get": "^4.4.2"
   },

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -280,7 +280,7 @@ export class SoqlParser extends CstParser {
 
   private conditionExpression = this.RULE(
     'conditionExpression',
-    (parenCount?: ParenCount, allowSubquery?: boolean, alowAggregateFn?: boolean, allowLocationFn?: boolean) => {
+    (parenCount?: ParenCount, allowSubquery?: boolean, allowAggregateFn?: boolean, allowLocationFn?: boolean) => {
       // argument is undefined during self-analysis, need to initialize to avoid exception
       parenCount = this.getParenCount(parenCount);
       this.OPTION(() => {
@@ -300,7 +300,7 @@ export class SoqlParser extends CstParser {
 
       this.OR1({
         MAX_LOOKAHEAD: 10,
-        DEF: [{ ALT: () => this.SUBRULE(this.expression, { ARGS: [parenCount, allowSubquery, alowAggregateFn, allowLocationFn] }) }],
+        DEF: [{ ALT: () => this.SUBRULE(this.expression, { ARGS: [parenCount, allowSubquery, allowAggregateFn, allowLocationFn] }) }],
       });
     },
   );
@@ -372,7 +372,7 @@ export class SoqlParser extends CstParser {
     const parenCount = this.getParenCount();
     this.AT_LEAST_ONE({
       DEF: () => {
-        this.SUBRULE(this.conditionExpression, { ARGS: [parenCount, true] });
+        this.SUBRULE(this.conditionExpression, { ARGS: [parenCount, true, undefined, undefined] });
       },
     });
 
@@ -564,7 +564,7 @@ export class SoqlParser extends CstParser {
 
   private expression = this.RULE(
     'expression',
-    (parenCount?: ParenCount, allowSubquery?: boolean, alowAggregateFn?: boolean, allowLocationFn?: boolean) => {
+    (parenCount?: ParenCount, allowSubquery?: boolean, allowAggregateFn?: boolean, allowLocationFn?: boolean) => {
       this.OPTION1(() => {
         this.MANY1(() => {
           this.CONSUME(lexer.LParen);
@@ -575,7 +575,7 @@ export class SoqlParser extends CstParser {
       });
 
       this.OR1([
-        { GATE: () => alowAggregateFn, ALT: () => this.SUBRULE(this.aggregateFunction, { LABEL: 'lhs' }) },
+        { GATE: () => allowAggregateFn, ALT: () => this.SUBRULE(this.aggregateFunction, { LABEL: 'lhs' }) },
         { GATE: () => allowLocationFn, ALT: () => this.SUBRULE(this.locationFunction, { LABEL: 'lhs' }) },
         { ALT: () => this.SUBRULE(this.dateFunction, { LABEL: 'lhs' }) },
         { ALT: () => this.SUBRULE(this.otherFunction, { LABEL: 'lhs' }) },
@@ -611,7 +611,7 @@ export class SoqlParser extends CstParser {
     this.SUBRULE2(this.atomicExpression, { LABEL: 'rhs', ARGS: [true, allowSubquery] });
   });
 
-  private atomicExpression = this.RULE('atomicExpression', (isArray, allowSubquery?: boolean) => {
+  private atomicExpression = this.RULE('atomicExpression', (isArray?: boolean, allowSubquery?: boolean) => {
     this.OR(
       this.$_atomicExpression ||
         (this.$_atomicExpression = [

--- a/test/performance-test.spec.ts
+++ b/test/performance-test.spec.ts
@@ -24,7 +24,7 @@ describe.skip('parse queries', () => {
     for (let i = 0; i < numIterations; i++) {
       testCases.forEach(testCase => {
         try {
-          parseQuery(testCase.soql, { allowApexBindVariables: true, logErrors: true });
+          parseQuery(testCase.soql, { allowApexBindVariables: true, logErrors: true, ...testCase.options });
         } catch (ex) {
           console.log('Exception on TC', testCase.testCase, testCase.soql);
           console.log(ex);


### PR DESCRIPTION
Hello @paustint,

I bumped chevrotain to the latest version too.

> 10.0.0
> Dropped support for legacy ES5.1 runtimes (e.g: IE11) The minimum ECMAScript version needed to run Chevrotain is 
> now ES2015 (ES6). This should not affect anyone running on a modern engine,
> meaning modern NodeJS versions or popular evergreen browsers.
>
> Various TypeScript signatures are now more accurate and strict which could potentially cause compilation errors with 
> some grammars implemented in TypeScript, e.g:
>
> OPTION methods now return OUT | undefined instead of just OUT.
> A RULE implementation function in CstParser is now defined as returning void.
> The ARGS for SubruleMethodOpts options type is now better enforced via generics in the subrule definition.

https://chevrotain.io/docs/changes/BREAKING_CHANGES.html

I only had to fix some optional types, build and tests are passing green.

![image](https://github.com/jetstreamapp/soql-parser-js/assets/15971247/e0432de4-cbc1-4dde-853e-f9e13aa358a2)
