### PR TITLE
Fixed composeQuery whereClause bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.9.1
+
+May 29, 2023
+
+Fixed bug with composeQuery when some of the WHERE clause values were not strings.
+
 ## 4.9.0
 
 May 23, 2023
@@ -470,7 +476,6 @@ export type FieldType =
 -}
 
 +export type HavingClause = HavingClauseWithoutOperator | HavingClauseWithRightCondition;
-
 ```
 
 ## 2.5.5
@@ -851,7 +856,6 @@ export interface FunctionExp {
   isAggregateFn?: boolean;
 - fn?: FunctionExp;
 }
-
 ```
 
 ## 1.2.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "soql-parser-js",
       "version": "4.9.0",
       "license": "MIT",
       "dependencies": {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -243,10 +243,10 @@ export function getWhereValue(value: any | any[], literalType?: LiteralType | Li
     switch (literalType) {
       case 'STRING': {
         if (Array.isArray(value)) {
-          return value.filter(Boolean).map(val => ((val as string).startsWith("'") ? val : `'${val ?? ''}'`));
+          return value.filter(Boolean).map(val => (isString(val) && val.startsWith("'") ? val : `'${val ?? ''}'`));
         } else {
           value = String(value ?? '');
-          return value.startsWith("'") ? value : `'${value}'`;
+          return isString(value) && value.startsWith("'") ? value : `'${value ?? ''}'`;
         }
       }
       case 'APEX_BIND_VARIABLE': {
@@ -262,8 +262,7 @@ export function getWhereValue(value: any | any[], literalType?: LiteralType | Li
 function whereValueHelper(value: any, literalType?: LiteralType) {
   switch (literalType) {
     case 'STRING': {
-      value = String(value ?? '');
-      return value.startsWith("'") ? value : `'${value ?? ''}'`;
+      return isString(value) && value.startsWith("'") ? value : `'${value ?? ''}'`;
     }
     default: {
       return value;

--- a/test/test-cases-compose.ts
+++ b/test/test-cases-compose.ts
@@ -81,6 +81,81 @@ export const testCases: TestCase[] = [
       },
     },
   },
+  {
+    testCase: 6,
+    soql: "SELECT Id, Fax FROM Account WHERE Fax IN ('55', 'foo')",
+    input: {
+      sObject: 'Account',
+      fields: [
+        {
+          type: 'Field',
+          field: 'Id',
+        },
+        {
+          type: 'Field',
+          field: 'Fax',
+        },
+      ],
+      where: {
+        left: {
+          field: 'Fax',
+          operator: 'IN',
+          value: [55, null, undefined, 'foo'],
+          literalType: 'STRING',
+        },
+      },
+    },
+  },
+  {
+    testCase: 7,
+    soql: "SELECT Id, Fax FROM Account WHERE Fax IN ('55')",
+    input: {
+      sObject: 'Account',
+      fields: [
+        {
+          type: 'Field',
+          field: 'Id',
+        },
+        {
+          type: 'Field',
+          field: 'Fax',
+        },
+      ],
+      where: {
+        left: {
+          field: 'Fax',
+          operator: 'IN',
+          value: 55 as any,
+          literalType: 'STRING',
+        },
+      },
+    },
+  },
+  {
+    testCase: 7,
+    soql: "SELECT Id, Fax FROM Account WHERE Fax = '55'",
+    input: {
+      sObject: 'Account',
+      fields: [
+        {
+          type: 'Field',
+          field: 'Id',
+        },
+        {
+          type: 'Field',
+          field: 'Fax',
+        },
+      ],
+      where: {
+        left: {
+          field: 'Fax',
+          operator: '=',
+          value: 55 as any,
+          literalType: 'STRING',
+        },
+      },
+    },
+  },
 ];
 
 export default testCases;

--- a/test/test-cases.ts
+++ b/test/test-cases.ts
@@ -284,8 +284,7 @@ export const testCases: TestCase[] = [
   },
   {
     testCase: 21,
-    soql:
-      'SELECT TYPEOF What WHEN Account THEN Phone, NumberOfEmployees WHEN Opportunity THEN Amount, CloseDate ELSE Name, Email END FROM Event',
+    soql: 'SELECT TYPEOF What WHEN Account THEN Phone, NumberOfEmployees WHEN Opportunity THEN Amount, CloseDate ELSE Name, Email END FROM Event',
     output: {
       fields: [
         {
@@ -320,8 +319,7 @@ export const testCases: TestCase[] = [
   },
   {
     testCase: 23,
-    soql:
-      'SELECT Amount, Id, Name, (SELECT Quantity, ListPrice, PricebookEntry.UnitPrice, PricebookEntry.Name FROM OpportunityLineItems) FROM Opportunity',
+    soql: 'SELECT Amount, Id, Name, (SELECT Quantity, ListPrice, PricebookEntry.UnitPrice, PricebookEntry.Name FROM OpportunityLineItems) FROM Opportunity',
     output: {
       fields: [
         { type: 'Field', field: 'Amount' },
@@ -361,8 +359,7 @@ export const testCases: TestCase[] = [
   },
   {
     testCase: 25,
-    soql:
-      'SELECT UserId, COUNT(Id) FROM LoginHistory WHERE LoginTime > 2010-09-20T22:16:30.000Z AND LoginTime < 2010-09-21 GROUP BY UserId',
+    soql: 'SELECT UserId, COUNT(Id) FROM LoginHistory WHERE LoginTime > 2010-09-20T22:16:30.000Z AND LoginTime < 2010-09-21 GROUP BY UserId',
     output: {
       fields: [
         { type: 'Field', field: 'UserId' },
@@ -464,8 +461,7 @@ export const testCases: TestCase[] = [
   },
   {
     testCase: 30,
-    soql:
-      'SELECT Type, BillingCountry, GROUPING(Type)grpType, GROUPING(BillingCountry) grpCty, COUNT(id) accts FROM Account GROUP BY CUBE(Type,BillingCountry) ORDER BY GROUPING(Type), GROUPING(Id,BillingCountry), Name DESC NULLS FIRST, Id ASC NULLS LAST',
+    soql: 'SELECT Type, BillingCountry, GROUPING(Type)grpType, GROUPING(BillingCountry) grpCty, COUNT(id) accts FROM Account GROUP BY CUBE(Type,BillingCountry) ORDER BY GROUPING(Type), GROUPING(Id,BillingCountry), Name DESC NULLS FIRST, Id ASC NULLS LAST',
     soqlComposed:
       'SELECT Type, BillingCountry, GROUPING(Type) grpType, GROUPING(BillingCountry) grpCty, COUNT(id) accts FROM Account GROUP BY CUBE(Type, BillingCountry) ORDER BY GROUPING(Type), GROUPING(Id, BillingCountry), Name DESC NULLS FIRST, Id ASC NULLS LAST',
     output: {
@@ -519,8 +515,7 @@ export const testCases: TestCase[] = [
   },
   {
     testCase: 32,
-    soql:
-      "SELECT Id FROM Account WHERE (Id IN ('1', '2', '3') OR (NOT Id = '2') OR (Name LIKE '%FOO%' OR (Name LIKE '%ARM%' AND FOO = 'bar')))",
+    soql: "SELECT Id FROM Account WHERE (Id IN ('1', '2', '3') OR (NOT Id = '2') OR (Name LIKE '%FOO%' OR (Name LIKE '%ARM%' AND FOO = 'bar')))",
     output: {
       fields: [{ type: 'Field', field: 'Id' }],
       sObject: 'Account',
@@ -637,8 +632,7 @@ export const testCases: TestCase[] = [
   },
   {
     testCase: 37,
-    soql:
-      "SELECT UrlName FROM KnowledgeArticleVersion WHERE PublishStatus = 'draft' WITH DATA CATEGORY Geography__c AT usa__c AND Product__c ABOVE_OR_BELOW mobile_phones__c",
+    soql: "SELECT UrlName FROM KnowledgeArticleVersion WHERE PublishStatus = 'draft' WITH DATA CATEGORY Geography__c AT usa__c AND Product__c ABOVE_OR_BELOW mobile_phones__c",
     output: {
       fields: [{ type: 'Field', field: 'UrlName' }],
       sObject: 'KnowledgeArticleVersion',
@@ -683,8 +677,7 @@ export const testCases: TestCase[] = [
   },
   {
     testCase: 44,
-    soql:
-      "SELECT amount, FORMAT(amount) Amt, convertCurrency(amount) editDate, FORMAT(convertCurrency(amount)) convertedCurrency FROM Opportunity WHERE id = '12345'",
+    soql: "SELECT amount, FORMAT(amount) Amt, convertCurrency(amount) editDate, FORMAT(convertCurrency(amount)) convertedCurrency FROM Opportunity WHERE id = '12345'",
     output: {
       fields: [
         { type: 'Field', field: 'amount' },
@@ -809,8 +802,7 @@ export const testCases: TestCase[] = [
   },
   {
     testCase: 49,
-    soql:
-      "SELECT Id, Name FROM Account WHERE Id IN (SELECT AccountId FROM Contact WHERE LastName LIKE 'apple%') AND Id IN (SELECT AccountId FROM Opportunity WHERE isClosed = FALSE)",
+    soql: "SELECT Id, Name FROM Account WHERE Id IN (SELECT AccountId FROM Contact WHERE LastName LIKE 'apple%') AND Id IN (SELECT AccountId FROM Opportunity WHERE isClosed = FALSE)",
     output: {
       fields: [
         { type: 'Field', field: 'Id' },
@@ -939,8 +931,7 @@ export const testCases: TestCase[] = [
   },
   {
     testCase: 55,
-    soql:
-      'SELECT Id, CreatedById, CreatedDate, DefType, IsDeleted, Format, LastModifiedById, LastModifiedDate, AuraDefinitionBundleId, ManageableState, Source, SystemModstamp FROM AuraDefinition',
+    soql: 'SELECT Id, CreatedById, CreatedDate, DefType, IsDeleted, Format, LastModifiedById, LastModifiedDate, AuraDefinitionBundleId, ManageableState, Source, SystemModstamp FROM AuraDefinition',
     output: {
       fields: [
         { type: 'Field', field: 'Id' },
@@ -974,8 +965,7 @@ export const testCases: TestCase[] = [
   },
   {
     testCase: 57,
-    soql:
-      "SELECT Title FROM KnowledgeArticleVersion WHERE PublishStatus = 'online' WITH DATA CATEGORY Geography__c ABOVE usa__c WITH SECURITY_ENFORCED",
+    soql: "SELECT Title FROM KnowledgeArticleVersion WHERE PublishStatus = 'online' WITH DATA CATEGORY Geography__c ABOVE usa__c WITH SECURITY_ENFORCED",
     output: {
       fields: [{ type: 'Field', field: 'Title' }],
       sObject: 'KnowledgeArticleVersion',
@@ -986,8 +976,7 @@ export const testCases: TestCase[] = [
   },
   {
     testCase: 58,
-    soql:
-      "SELECT Id FROM Account WHERE (((Name = '1' OR Name = '2') AND Name = '3')) AND (((Description = '123') OR (Id = '1' AND Id = '2'))) AND Id = '1'",
+    soql: "SELECT Id FROM Account WHERE (((Name = '1' OR Name = '2') AND Name = '3')) AND (((Description = '123') OR (Id = '1' AND Id = '2'))) AND Id = '1'",
     output: {
       fields: [{ type: 'Field', field: 'Id' }],
       sObject: 'Account',
@@ -1190,8 +1179,7 @@ export const testCases: TestCase[] = [
   },
   {
     testCase: 71,
-    soql:
-      'SELECT CALENDAR_YEAR(convertTimezone(CreatedDate)) calYear, SUM(Amount) mySum FROM Opportunity GROUP BY CALENDAR_YEAR(convertTimezone(CreatedDate))',
+    soql: 'SELECT CALENDAR_YEAR(convertTimezone(CreatedDate)) calYear, SUM(Amount) mySum FROM Opportunity GROUP BY CALENDAR_YEAR(convertTimezone(CreatedDate))',
     output: {
       fields: [
         {
@@ -1341,8 +1329,7 @@ export const testCases: TestCase[] = [
   },
   {
     testCase: 79,
-    soql:
-      'SELECT LeadSource, Rating, GROUPING(LeadSource) grpLS, GROUPING(Rating) grpRating, COUNT(Name) cnt FROM Lead GROUP BY ROLLUP(LeadSource, Rating)',
+    soql: 'SELECT LeadSource, Rating, GROUPING(LeadSource) grpLS, GROUPING(Rating) grpRating, COUNT(Name) cnt FROM Lead GROUP BY ROLLUP(LeadSource, Rating)',
     output: {
       fields: [
         { type: 'Field', field: 'LeadSource' },
@@ -1376,8 +1363,7 @@ export const testCases: TestCase[] = [
   },
   {
     testCase: 80,
-    soql:
-      'SELECT Type, BillingCountry, GROUPING(Type) grpType, GROUPING(BillingCountry) grpCty, COUNT(id) accts FROM Account GROUP BY CUBE(Type, BillingCountry) ORDER BY GROUPING(Type), GROUPING(BillingCountry)',
+    soql: 'SELECT Type, BillingCountry, GROUPING(Type) grpType, GROUPING(BillingCountry) grpCty, COUNT(id) accts FROM Account GROUP BY CUBE(Type, BillingCountry) ORDER BY GROUPING(Type), GROUPING(BillingCountry)',
     output: {
       fields: [
         { type: 'Field', field: 'Type' },
@@ -1415,8 +1401,7 @@ export const testCases: TestCase[] = [
   },
   {
     testCase: 81,
-    soql:
-      'SELECT HOUR_IN_DAY(convertTimezone(CreatedDate)), SUM(Amount) FROM Opportunity GROUP BY HOUR_IN_DAY(convertTimezone(CreatedDate))',
+    soql: 'SELECT HOUR_IN_DAY(convertTimezone(CreatedDate)), SUM(Amount) FROM Opportunity GROUP BY HOUR_IN_DAY(convertTimezone(CreatedDate))',
     output: {
       fields: [
         {
@@ -1907,8 +1892,7 @@ export const testCases: TestCase[] = [
   },
   {
     testCase: 101,
-    soql:
-      'SELECT Id FROM LoginHistory WHERE LoginTime > 2020-04-23T09:00:00.00000000000000000000000000000000+00:00 AND LoginTime < 2020-04-15T02:40:03.000+0000',
+    soql: 'SELECT Id FROM LoginHistory WHERE LoginTime > 2020-04-23T09:00:00.00000000000000000000000000000000+00:00 AND LoginTime < 2020-04-15T02:40:03.000+0000',
     output: {
       fields: [{ type: 'Field', field: 'Id' }],
       sObject: 'LoginHistory',
@@ -2404,6 +2388,28 @@ export const testCases: TestCase[] = [
   },
   {
     testCase: 118,
+    options: { allowApexBindVariables: true },
+    soql: `SELECT Name FROM Account WHERE Name IN ('GenePoint\\'s \\n Ok!?!@#$^%$&*()_+')`,
+    output: {
+      fields: [
+        {
+          type: 'Field',
+          field: 'Name',
+        },
+      ],
+      sObject: 'Account',
+      where: {
+        left: {
+          field: 'Name',
+          literalType: 'STRING',
+          operator: 'IN',
+          value: [`'GenePoint\\'s \\n Ok!?!@#$^%$&*()_+'`],
+        },
+      },
+    },
+  },
+  {
+    testCase: 119,
     options: { allowApexBindVariables: true },
     soql: `SELECT State_Abbr_c FROM Contact WHERE State_Abbr_c = 'MI' OR State_Abbr_c = 'km'`,
     output: {


### PR DESCRIPTION
If any provided values were not strings (e.x. number) then an exception would be thrown