### PR TITLE
Fix incorrect parsing for NOT negation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 4.10.0
+
+Jan 13, 2024
+
+- Fixed where clause's that have a field name beginning with `In` preceded by the `NOT` operator. These were parsed as `NOT IN` instead of `NOT` followed by a field name, example: `NOT Invoice__c`
+  - https://github.com/jetstreamapp/jetstream/issues/702
+- Fixed queries that have two consecutive `NOT` operators (#237)
+- Enabled Typescript strict mode and made a number of minor fixes related to this.
+- When using `getField` which return `FieldFunctionExpression` will now always return an empty array even if no parameters are provided.
+
 ## 4.9.2
 
 July 24, 2023

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "soql-parser-js",
       "version": "4.9.2",
       "license": "MIT",
       "dependencies": {

--- a/src/api/api-models.ts
+++ b/src/api/api-models.ts
@@ -157,7 +157,7 @@ export interface Subquery extends QueryBase {
 export type WhereClause = WhereClauseWithoutOperator | WhereClauseWithRightCondition;
 
 export interface WhereClauseWithoutOperator {
-  left: ConditionWithValueQuery;
+  left: ConditionWithValueQuery | null;
 }
 
 export interface WhereClauseWithRightCondition extends WhereClauseWithoutOperator {

--- a/src/api/public-utils.ts
+++ b/src/api/public-utils.ts
@@ -100,7 +100,7 @@ export function getField(input: string | ComposeFieldInput): SoqlModels.FieldTyp
       field: input,
     };
   } else if (isComposeFieldFunction(input)) {
-    let parameters: string[] | SoqlModels.FieldFunctionExpression[];
+    let parameters: string[] | SoqlModels.FieldFunctionExpression[] = [];
     if (input.parameters) {
       parameters = (Array.isArray(input.parameters) ? input.parameters : [input.parameters]) as
         | string[]
@@ -108,7 +108,7 @@ export function getField(input: string | ComposeFieldInput): SoqlModels.FieldTyp
     }
     return {
       type: 'FieldFunctionExpression',
-      functionName: input.functionName || input.fn,
+      functionName: (input.functionName || input.fn)!,
       parameters,
       alias: input.alias,
     };
@@ -122,7 +122,7 @@ export function getField(input: string | ComposeFieldInput): SoqlModels.FieldTyp
   } else if (isComposeFieldSubquery(input)) {
     return {
       type: 'FieldSubquery',
-      subquery: input.subquery,
+      subquery: input.subquery!,
     };
   } else if (isComposeFieldTypeof(input)) {
     return {
@@ -259,7 +259,7 @@ export function getFlattenedFields(
           break;
       }
     })
-    .filter(field => isString(field));
+    .filter(field => isString(field)) as string[];
 
   return parsedFields;
 }

--- a/src/composer/composer.ts
+++ b/src/composer/composer.ts
@@ -76,8 +76,8 @@ export class Compose {
   constructor(private soql: Query, config: Partial<SoqlComposeConfig> = {}) {
     config = { autoCompose: true, ...config };
     const { logging, format } = config;
-    this.logging = logging;
-    this.format = format;
+    this.logging = !!logging;
+    this.format = !!format;
     this.query = '';
 
     this.formatter = new Formatter(this.format, {
@@ -126,7 +126,7 @@ export class Compose {
       output += ` ${fn.alias}`;
     }
 
-    return output;
+    return output!;
   }
 
   /**
@@ -262,7 +262,7 @@ export class Compose {
   public parseFields(fields: FieldType[]): { text: string; typeOfClause?: string[] }[] {
     return fields.map(field => {
       let text = '';
-      let typeOfClause: string[];
+      let typeOfClause: string[] | undefined;
 
       const objPrefix = (field as any).objectPrefix ? `${(field as any).objectPrefix}.` : '';
       switch (field.type) {

--- a/src/models.ts
+++ b/src/models.ts
@@ -18,7 +18,7 @@ export interface ExpressionTree<T> {
  */
 
 interface WithIdentifier {
-  Identifier?: IToken[];
+  Identifier: IToken[];
 }
 
 export interface SelectStatementContext {
@@ -61,7 +61,7 @@ export interface SelectClauseFunctionIdentifierContext extends WithIdentifier {
 }
 
 export interface SelectClauseSubqueryIdentifierContext extends WithIdentifier {
-  selectStatement?: CstNode[];
+  selectStatement: CstNode[];
 }
 
 export interface SelectClauseTypeOfContext extends WithIdentifier {
@@ -102,10 +102,24 @@ export interface ConditionExpressionContext {
   expression: CstNode[];
 }
 
-export interface WithClauseContext {
-  withSecurityEnforced?: CstNode[];
-  withAccessLevel?: IToken[];
-  withDataCategory?: CstNode[];
+export type WithClauseContext = WithSecurityEnforcedClauseContext | WithAccessLevelClauseContext | WithDataCategoryClauseContext;
+
+export interface WithSecurityEnforcedClauseContext {
+  withSecurityEnforced: CstNode[];
+  withAccessLevel?: never;
+  withDataCategory?: never;
+}
+
+export interface WithAccessLevelClauseContext {
+  withSecurityEnforced?: never;
+  withAccessLevel: IToken[];
+  withDataCategory?: never;
+}
+
+export interface WithDataCategoryClauseContext {
+  withSecurityEnforced?: never;
+  withAccessLevel?: never;
+  withDataCategory: CstNode[];
 }
 
 export interface WithDateCategoryContext {
@@ -161,6 +175,17 @@ export interface ValueContext {
 
 export interface OperatorContext {
   operator: IToken[];
+}
+
+export type OperatorOrNotInContext = OperatorWithoutNotInContext | OperatorNotInContext;
+
+export interface OperatorWithoutNotInContext extends OperatorContext {
+  notIn?: never;
+}
+
+export interface OperatorNotInContext {
+  operator?: never;
+  notIn: CstNode[];
 }
 
 export interface BooleanContext {
@@ -249,10 +274,22 @@ export interface ApexBindVariableFunctionArrayAccessorContext {
   value: IToken[];
 }
 
-export interface ExpressionOperatorContext {
+export type ExpressionOperatorContext = ExpressionOperatorRhsContext & ExpressionWithRelationalOrSetOperatorContext;
+
+export interface ExpressionOperatorRhsContext {
   rhs: CstNode[];
-  relationalOperator?: CstNode[];
-  setOperator?: CstNode[];
+}
+
+type ExpressionWithRelationalOrSetOperatorContext = ExpressionWithRelationalOperatorContext | ExpressionWithSetOperatorOperatorContext;
+
+export interface ExpressionWithRelationalOperatorContext {
+  relationalOperator: CstNode[];
+  setOperator?: never;
+}
+
+export interface ExpressionWithSetOperatorOperatorContext {
+  relationalOperator?: never;
+  setOperator: CstNode[];
 }
 
 export interface FromClauseContext extends WithIdentifier {

--- a/src/parser/lexer.ts
+++ b/src/parser/lexer.ts
@@ -230,9 +230,6 @@ export const GroupBy = createToken({ name: 'GROUP_BY', pattern: /GROUP BY/i, lon
 export const Having = createToken({ name: 'HAVING', pattern: /HAVING/i, longer_alt: Identifier, categories: [Keyword, ReservedKeyword] });
 export const In = createToken({ name: 'IN', pattern: /IN/i, longer_alt: Identifier, categories: [Keyword, ReservedKeyword] });
 
-// FIXME: split into two tokens, NOT is a reserved keyword, IN is not
-export const NotIn = createToken({ name: 'NOT_IN', pattern: /NOT IN/i, longer_alt: Identifier });
-
 export const Includes = createToken({
   name: 'INCLUDES',
   pattern: /INCLUDES/i,
@@ -1025,7 +1022,6 @@ export const allTokens = [
   Standard,
 
   In,
-  NotIn,
   For,
   Or,
   Last,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -231,7 +231,7 @@ export function getWhereValue(value: any | any[], literalType?: LiteralType | Li
 
   if (Array.isArray(literalType) && Array.isArray(value)) {
     return value.map((val, i) => {
-      return whereValueHelper(val, literalType[i] as LiteralType);
+      return whereValueHelper(val, literalType?.[i] as LiteralType);
     });
   } else {
     // This path should never hit, but on the off chance that literal type is an array and value is a string

--- a/test/public-utils.spec.ts
+++ b/test/public-utils.spec.ts
@@ -21,7 +21,7 @@ describe('getField', () => {
     expect(utils.getField({ functionName: 'COUNT' })).toEqual({
       type: 'FieldFunctionExpression',
       functionName: 'COUNT',
-      parameters: undefined,
+      parameters: [],
       alias: undefined,
     });
     expect(utils.getField({ functionName: 'FORMAT', parameters: ['Amount'] })).toEqual({

--- a/test/test-cases.ts
+++ b/test/test-cases.ts
@@ -1,4 +1,4 @@
-import { Query } from '../src/api/api-models';
+import { Query, ValueWithDateNLiteralCondition } from '../src/api/api-models';
 import { ParseQueryConfig } from '../src/parser/parser';
 // Queries obtained from SFDC examples
 // https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql_select_examples.htm
@@ -284,7 +284,8 @@ export const testCases: TestCase[] = [
   },
   {
     testCase: 21,
-    soql: 'SELECT TYPEOF What WHEN Account THEN Phone, NumberOfEmployees WHEN Opportunity THEN Amount, CloseDate ELSE Name, Email END FROM Event',
+    soql:
+      'SELECT TYPEOF What WHEN Account THEN Phone, NumberOfEmployees WHEN Opportunity THEN Amount, CloseDate ELSE Name, Email END FROM Event',
     output: {
       fields: [
         {
@@ -319,7 +320,8 @@ export const testCases: TestCase[] = [
   },
   {
     testCase: 23,
-    soql: 'SELECT Amount, Id, Name, (SELECT Quantity, ListPrice, PricebookEntry.UnitPrice, PricebookEntry.Name FROM OpportunityLineItems) FROM Opportunity',
+    soql:
+      'SELECT Amount, Id, Name, (SELECT Quantity, ListPrice, PricebookEntry.UnitPrice, PricebookEntry.Name FROM OpportunityLineItems) FROM Opportunity',
     output: {
       fields: [
         { type: 'Field', field: 'Amount' },
@@ -359,7 +361,8 @@ export const testCases: TestCase[] = [
   },
   {
     testCase: 25,
-    soql: 'SELECT UserId, COUNT(Id) FROM LoginHistory WHERE LoginTime > 2010-09-20T22:16:30.000Z AND LoginTime < 2010-09-21 GROUP BY UserId',
+    soql:
+      'SELECT UserId, COUNT(Id) FROM LoginHistory WHERE LoginTime > 2010-09-20T22:16:30.000Z AND LoginTime < 2010-09-21 GROUP BY UserId',
     output: {
       fields: [
         { type: 'Field', field: 'UserId' },
@@ -461,7 +464,8 @@ export const testCases: TestCase[] = [
   },
   {
     testCase: 30,
-    soql: 'SELECT Type, BillingCountry, GROUPING(Type)grpType, GROUPING(BillingCountry) grpCty, COUNT(id) accts FROM Account GROUP BY CUBE(Type,BillingCountry) ORDER BY GROUPING(Type), GROUPING(Id,BillingCountry), Name DESC NULLS FIRST, Id ASC NULLS LAST',
+    soql:
+      'SELECT Type, BillingCountry, GROUPING(Type)grpType, GROUPING(BillingCountry) grpCty, COUNT(id) accts FROM Account GROUP BY CUBE(Type,BillingCountry) ORDER BY GROUPING(Type), GROUPING(Id,BillingCountry), Name DESC NULLS FIRST, Id ASC NULLS LAST',
     soqlComposed:
       'SELECT Type, BillingCountry, GROUPING(Type) grpType, GROUPING(BillingCountry) grpCty, COUNT(id) accts FROM Account GROUP BY CUBE(Type, BillingCountry) ORDER BY GROUPING(Type), GROUPING(Id, BillingCountry), Name DESC NULLS FIRST, Id ASC NULLS LAST',
     output: {
@@ -515,7 +519,8 @@ export const testCases: TestCase[] = [
   },
   {
     testCase: 32,
-    soql: "SELECT Id FROM Account WHERE (Id IN ('1', '2', '3') OR (NOT Id = '2') OR (Name LIKE '%FOO%' OR (Name LIKE '%ARM%' AND FOO = 'bar')))",
+    soql:
+      "SELECT Id FROM Account WHERE (Id IN ('1', '2', '3') OR (NOT Id = '2') OR (Name LIKE '%FOO%' OR (Name LIKE '%ARM%' AND FOO = 'bar')))",
     output: {
       fields: [{ type: 'Field', field: 'Id' }],
       sObject: 'Account',
@@ -632,7 +637,8 @@ export const testCases: TestCase[] = [
   },
   {
     testCase: 37,
-    soql: "SELECT UrlName FROM KnowledgeArticleVersion WHERE PublishStatus = 'draft' WITH DATA CATEGORY Geography__c AT usa__c AND Product__c ABOVE_OR_BELOW mobile_phones__c",
+    soql:
+      "SELECT UrlName FROM KnowledgeArticleVersion WHERE PublishStatus = 'draft' WITH DATA CATEGORY Geography__c AT usa__c AND Product__c ABOVE_OR_BELOW mobile_phones__c",
     output: {
       fields: [{ type: 'Field', field: 'UrlName' }],
       sObject: 'KnowledgeArticleVersion',
@@ -677,7 +683,8 @@ export const testCases: TestCase[] = [
   },
   {
     testCase: 44,
-    soql: "SELECT amount, FORMAT(amount) Amt, convertCurrency(amount) editDate, FORMAT(convertCurrency(amount)) convertedCurrency FROM Opportunity WHERE id = '12345'",
+    soql:
+      "SELECT amount, FORMAT(amount) Amt, convertCurrency(amount) editDate, FORMAT(convertCurrency(amount)) convertedCurrency FROM Opportunity WHERE id = '12345'",
     output: {
       fields: [
         { type: 'Field', field: 'amount' },
@@ -802,7 +809,8 @@ export const testCases: TestCase[] = [
   },
   {
     testCase: 49,
-    soql: "SELECT Id, Name FROM Account WHERE Id IN (SELECT AccountId FROM Contact WHERE LastName LIKE 'apple%') AND Id IN (SELECT AccountId FROM Opportunity WHERE isClosed = FALSE)",
+    soql:
+      "SELECT Id, Name FROM Account WHERE Id IN (SELECT AccountId FROM Contact WHERE LastName LIKE 'apple%') AND Id IN (SELECT AccountId FROM Opportunity WHERE isClosed = FALSE)",
     output: {
       fields: [
         { type: 'Field', field: 'Id' },
@@ -931,7 +939,8 @@ export const testCases: TestCase[] = [
   },
   {
     testCase: 55,
-    soql: 'SELECT Id, CreatedById, CreatedDate, DefType, IsDeleted, Format, LastModifiedById, LastModifiedDate, AuraDefinitionBundleId, ManageableState, Source, SystemModstamp FROM AuraDefinition',
+    soql:
+      'SELECT Id, CreatedById, CreatedDate, DefType, IsDeleted, Format, LastModifiedById, LastModifiedDate, AuraDefinitionBundleId, ManageableState, Source, SystemModstamp FROM AuraDefinition',
     output: {
       fields: [
         { type: 'Field', field: 'Id' },
@@ -965,7 +974,8 @@ export const testCases: TestCase[] = [
   },
   {
     testCase: 57,
-    soql: "SELECT Title FROM KnowledgeArticleVersion WHERE PublishStatus = 'online' WITH DATA CATEGORY Geography__c ABOVE usa__c WITH SECURITY_ENFORCED",
+    soql:
+      "SELECT Title FROM KnowledgeArticleVersion WHERE PublishStatus = 'online' WITH DATA CATEGORY Geography__c ABOVE usa__c WITH SECURITY_ENFORCED",
     output: {
       fields: [{ type: 'Field', field: 'Title' }],
       sObject: 'KnowledgeArticleVersion',
@@ -976,7 +986,8 @@ export const testCases: TestCase[] = [
   },
   {
     testCase: 58,
-    soql: "SELECT Id FROM Account WHERE (((Name = '1' OR Name = '2') AND Name = '3')) AND (((Description = '123') OR (Id = '1' AND Id = '2'))) AND Id = '1'",
+    soql:
+      "SELECT Id FROM Account WHERE (((Name = '1' OR Name = '2') AND Name = '3')) AND (((Description = '123') OR (Id = '1' AND Id = '2'))) AND Id = '1'",
     output: {
       fields: [{ type: 'Field', field: 'Id' }],
       sObject: 'Account',
@@ -1179,7 +1190,8 @@ export const testCases: TestCase[] = [
   },
   {
     testCase: 71,
-    soql: 'SELECT CALENDAR_YEAR(convertTimezone(CreatedDate)) calYear, SUM(Amount) mySum FROM Opportunity GROUP BY CALENDAR_YEAR(convertTimezone(CreatedDate))',
+    soql:
+      'SELECT CALENDAR_YEAR(convertTimezone(CreatedDate)) calYear, SUM(Amount) mySum FROM Opportunity GROUP BY CALENDAR_YEAR(convertTimezone(CreatedDate))',
     output: {
       fields: [
         {
@@ -1329,7 +1341,8 @@ export const testCases: TestCase[] = [
   },
   {
     testCase: 79,
-    soql: 'SELECT LeadSource, Rating, GROUPING(LeadSource) grpLS, GROUPING(Rating) grpRating, COUNT(Name) cnt FROM Lead GROUP BY ROLLUP(LeadSource, Rating)',
+    soql:
+      'SELECT LeadSource, Rating, GROUPING(LeadSource) grpLS, GROUPING(Rating) grpRating, COUNT(Name) cnt FROM Lead GROUP BY ROLLUP(LeadSource, Rating)',
     output: {
       fields: [
         { type: 'Field', field: 'LeadSource' },
@@ -1363,7 +1376,8 @@ export const testCases: TestCase[] = [
   },
   {
     testCase: 80,
-    soql: 'SELECT Type, BillingCountry, GROUPING(Type) grpType, GROUPING(BillingCountry) grpCty, COUNT(id) accts FROM Account GROUP BY CUBE(Type, BillingCountry) ORDER BY GROUPING(Type), GROUPING(BillingCountry)',
+    soql:
+      'SELECT Type, BillingCountry, GROUPING(Type) grpType, GROUPING(BillingCountry) grpCty, COUNT(id) accts FROM Account GROUP BY CUBE(Type, BillingCountry) ORDER BY GROUPING(Type), GROUPING(BillingCountry)',
     output: {
       fields: [
         { type: 'Field', field: 'Type' },
@@ -1401,7 +1415,8 @@ export const testCases: TestCase[] = [
   },
   {
     testCase: 81,
-    soql: 'SELECT HOUR_IN_DAY(convertTimezone(CreatedDate)), SUM(Amount) FROM Opportunity GROUP BY HOUR_IN_DAY(convertTimezone(CreatedDate))',
+    soql:
+      'SELECT HOUR_IN_DAY(convertTimezone(CreatedDate)), SUM(Amount) FROM Opportunity GROUP BY HOUR_IN_DAY(convertTimezone(CreatedDate))',
     output: {
       fields: [
         {
@@ -1793,7 +1808,7 @@ export const testCases: TestCase[] = [
           operator: 'IN',
           value: ['TODAY', 'LAST_N_DAYS:4'],
           dateLiteralVariable: [null, 4],
-        },
+        } as ValueWithDateNLiteralCondition,
       },
     },
   },
@@ -1892,7 +1907,8 @@ export const testCases: TestCase[] = [
   },
   {
     testCase: 101,
-    soql: 'SELECT Id FROM LoginHistory WHERE LoginTime > 2020-04-23T09:00:00.00000000000000000000000000000000+00:00 AND LoginTime < 2020-04-15T02:40:03.000+0000',
+    soql:
+      'SELECT Id FROM LoginHistory WHERE LoginTime > 2020-04-23T09:00:00.00000000000000000000000000000000+00:00 AND LoginTime < 2020-04-15T02:40:03.000+0000',
     output: {
       fields: [{ type: 'Field', field: 'Id' }],
       sObject: 'LoginHistory',
@@ -2531,6 +2547,91 @@ export const testCases: TestCase[] = [
       fields: [{ type: 'Field', field: 'Id' }],
       sObject: 'Account',
       withAccessLevel: 'SYSTEM_MODE',
+    },
+  },
+  {
+    testCase: 124,
+    soql: `SELECT Id, BillingCity FROM Account WHERE NOT (NOT BillingCity LIKE '%123%')`,
+    output: {
+      fields: [
+        { type: 'Field', field: 'Id' },
+        { type: 'Field', field: 'BillingCity' },
+      ],
+      sObject: 'Account',
+      where: {
+        left: null,
+        operator: 'NOT',
+        right: {
+          left: {
+            openParen: 1,
+          },
+          operator: 'NOT',
+          right: {
+            left: {
+              field: 'BillingCity',
+              operator: 'LIKE',
+              value: `'%123%'`,
+              literalType: 'STRING',
+              closeParen: 1,
+            },
+          },
+        },
+      },
+    },
+  },
+  {
+    testCase: 125,
+    soql: `SELECT Id FROM Account WHERE NOT (NOT Invoice_Type__c LIKE '%Usage%')`,
+    output: {
+      fields: [{ type: 'Field', field: 'Id' }],
+      sObject: 'Account',
+      where: {
+        left: null,
+        operator: 'NOT',
+        right: {
+          left: {
+            openParen: 1,
+          },
+          operator: 'NOT',
+          right: {
+            left: {
+              field: 'Invoice_Type__c',
+              operator: 'LIKE',
+              value: `'%Usage%'`,
+              literalType: 'STRING',
+              closeParen: 1,
+            },
+          },
+        },
+      },
+    },
+  },
+  {
+    testCase: 126,
+    soql: `SELECT Id FROM Account WHERE (NOT Invoice_Type__c LIKE '%Usage%')`,
+    output: {
+      fields: [
+        {
+          type: 'Field',
+          field: 'Id',
+        },
+      ],
+      sObject: 'Account',
+      where: {
+        left: {
+          openParen: 1,
+        },
+        operator: 'NOT',
+        right: {
+          left: {
+            field: 'Invoice_Type__c',
+            operator: 'LIKE',
+            literalType: 'STRING',
+            value: "'%Usage%'",
+            closeParen: 1,
+          },
+        },
+      },
     },
   },
 ];

--- a/tsconfig-esm.json
+++ b/tsconfig-esm.json
@@ -5,6 +5,7 @@
     "module": "esnext",
     "target": "es5",
     "outDir": "dist_esm",
+    "strict": true,
     "declaration": false,
     "typeRoots": ["node_modules/@types"]
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "outDir": "dist/src",
     "removeComments": true,
     "sourceMap": true,
+    "strict": true,
     "target": "es5",
     "typeRoots": ["node_modules/@types"]
   },


### PR DESCRIPTION
Ensure that all `expressionNegation` entries are visited instead of just the first one in the case where there aer multiple negations in a row

Removed `NOT IN` keyword in lexer to avoid false positives for identifiers (fields) that start with `In` preceded by `NOT`

Enable typescript strict mode to help enforce handling data properly - this required many minor updates.

Improved visitor types to better express actual shape of context