### PR TITLE
Breaking/v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 5.0.0
+
+Jan 13, 2024
+
+💥 Breaking Changes
+Fixed a bug where with typescript types to properly represent that `WhereClause` can have a null value for `left` in the case of a negation operator.
+This was always the case, but prior to enabling strict typescript types, this went under the radar.
+
+For Typescript consumers that have strict null checks enabled, they may need to make code changes depending on usage.
+
 ## 4.10.1
 
 Jan 13, 2024

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 4.10.1
+
+Jan 13, 2024
+
+Revert accidental breaking change to types. `WhereClause` left can have `null` in the negation case, but the types did not represent this.
+Updating types to match reality is a breaking change for consumers, so worked around issue and will publish version 5 with breaking change.
+
 ## 4.10.0
 
 Jan 13, 2024

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "soql-parser-js",
-  "version": "4.10.0",
+  "version": "4.10.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "4.10.0",
+      "version": "4.10.1",
       "license": "MIT",
       "dependencies": {
         "chevrotain": "^10.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soql-parser-js",
-  "version": "4.10.0",
+  "version": "4.10.1",
   "description": "Salesforce.com SOQL parser and composer",
   "main": "dist/index.js",
   "module": "dist_esm/index.js",

--- a/src/api/api-models.ts
+++ b/src/api/api-models.ts
@@ -1,4 +1,7 @@
-export type LogicalOperator = 'AND' | 'OR' | 'NOT';
+export type LogicalOperatorAnd = 'AND';
+export type LogicalOperatorOr = 'OR';
+export type LogicalOperatorNot = 'NOT';
+export type LogicalOperator = LogicalOperatorAnd | LogicalOperatorOr | LogicalOperatorNot;
 export type Operator = '=' | '!=' | '<=' | '>=' | '>' | '<' | 'LIKE' | 'IN' | 'NOT IN' | 'INCLUDES' | 'EXCLUDES';
 export type FieldTypeOfConditionType = 'WHEN' | 'ELSE';
 export type GroupSelector = 'ABOVE' | 'AT' | 'BELOW' | 'ABOVE_OR_BELOW';
@@ -154,7 +157,7 @@ export interface Subquery extends QueryBase {
   sObjectPrefix?: string[];
 }
 
-export type WhereClause = WhereClauseWithoutOperator | WhereClauseWithRightCondition;
+export type WhereClause = WhereClauseWithoutOperator | WhereClauseWithoutNegationOperator | WhereClauseWithRightCondition;
 
 export interface WhereClauseWithoutOperator {
   left: ConditionWithValueQuery;
@@ -162,6 +165,15 @@ export interface WhereClauseWithoutOperator {
 
 export interface WhereClauseWithRightCondition extends WhereClauseWithoutOperator {
   operator: LogicalOperator;
+  right: WhereClause;
+}
+
+/**
+ * This is a special case where the left side of the where clause can potentially be null if there is a negation without parentheses
+ */
+export interface WhereClauseWithoutNegationOperator {
+  left: NegationCondition | null;
+  operator: LogicalOperatorNot;
   right: WhereClause;
 }
 

--- a/src/api/api-models.ts
+++ b/src/api/api-models.ts
@@ -157,7 +157,7 @@ export interface Subquery extends QueryBase {
 export type WhereClause = WhereClauseWithoutOperator | WhereClauseWithRightCondition;
 
 export interface WhereClauseWithoutOperator {
-  left: ConditionWithValueQuery | null;
+  left: ConditionWithValueQuery;
 }
 
 export interface WhereClauseWithRightCondition extends WhereClauseWithoutOperator {

--- a/src/parser/visitor.ts
+++ b/src/parser/visitor.ts
@@ -30,6 +30,7 @@ import {
   ValueWithDateNLiteralCondition,
   WhereClause,
   WhereClauseWithRightCondition,
+  WhereClauseWithoutNegationOperator,
   WithDataCategoryCondition,
 } from '../api/api-models';
 import {
@@ -732,8 +733,8 @@ class SOQLVisitor extends BaseSoqlVisitor {
   }
 
   expressionPartWithNegation(ctx: any) {
-    const output: Partial<WhereClauseWithRightCondition> = {
-      left: ctx.L_PAREN ? { openParen: ctx.L_PAREN.length } : (null as any), // FIXME: type does not allow null, but changing is a breaking change
+    const output: Partial<WhereClauseWithoutNegationOperator> = {
+      left: ctx.L_PAREN ? { openParen: ctx.L_PAREN.length } : null,
       operator: 'NOT',
       right: {
         left: {} as ValueCondition,

--- a/src/parser/visitor.ts
+++ b/src/parser/visitor.ts
@@ -733,7 +733,7 @@ class SOQLVisitor extends BaseSoqlVisitor {
 
   expressionPartWithNegation(ctx: any) {
     const output: Partial<WhereClauseWithRightCondition> = {
-      left: ctx.L_PAREN ? { openParen: ctx.L_PAREN.length } : null,
+      left: ctx.L_PAREN ? { openParen: ctx.L_PAREN.length } : (null as any), // FIXME: type does not allow null, but changing is a breaking change
       operator: 'NOT',
       right: {
         left: {} as ValueCondition,


### PR DESCRIPTION
left is null in some cases but this is not represented in the type definitions - but representing there is a breaking change for consumers even though it truly could be null and cause bugs.

reverting change, then will release breaking package.