### PR TITLE
Nested Negation queries did not properly structure WHERE clauses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 5.0.2
+
+Jan 18, 2024
+
+- Nested NOT negation WHERE clauses were not properly formed (#242)
+
 ## 5.0.1
 
 Jan 13, 2024

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "soql-parser-js",
       "version": "5.0.1",
       "license": "MIT",
       "dependencies": {

--- a/test/test-cases.ts
+++ b/test/test-cases.ts
@@ -2634,6 +2634,53 @@ export const testCases: TestCase[] = [
       },
     },
   },
+  {
+    testCase: 127,
+    soql: `SELECT Id, City FROM Lead WHERE NOT ((NOT (City LIKE '%LHR%')) AND City LIKE '%KHR%')`,
+    output: {
+      fields: [
+        {
+          type: 'Field',
+          field: 'Id',
+        },
+        {
+          type: 'Field',
+          field: 'City',
+        },
+      ],
+      sObject: 'Lead',
+      where: {
+        left: null,
+        operator: 'NOT',
+        right: {
+          left: {
+            openParen: 2,
+          },
+          operator: 'NOT',
+          right: {
+            left: {
+              field: 'City',
+              operator: 'LIKE',
+              literalType: 'STRING',
+              value: "'%LHR%'",
+              openParen: 1,
+              closeParen: 2,
+            },
+            operator: 'AND',
+            right: {
+              left: {
+                field: 'City',
+                operator: 'LIKE',
+                literalType: 'STRING',
+                value: "'%KHR%'",
+                closeParen: 1,
+              },
+            },
+          },
+        },
+      },
+    },
+  },
 ];
 
 export default testCases;


### PR DESCRIPTION
Nested negation queries would return multiple nested expressions, but parsing the WHERE clause assumed that only one expression was returned from each visit to a condition.

This was solved by recursively walking the expressions until we came upon the final right expression to build upon instead of overwriting it.

resolves #242