### PR TITLE
fix types for esm build

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "types": "dist/types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "require": "./dist/cjs/index.js",
       "import": "./dist/esm/index.mjs"
     }


### PR DESCRIPTION
https://github.com/jetstreamapp/soql-parser-js/pull/261 fixed the build issues but I messed up and forgot to include the updated type path declaration. This is required for ESM.